### PR TITLE
fix: Add missing parameter to price calculation

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -12,7 +12,7 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        price = size_price + sum(ingredient.price for ingredient in ingredients)
         return round(price, 2)
 
     @classmethod


### PR DESCRIPTION
Trello ticket: [Fix order price calculation](https://trello.com/c/FqmOGG1G/9-fix-order-price-calculation-bonus)

Description: Running the tests for this calculation returned that the sum wasn't being done correctly. After reviewing the code, the problem was that the price of the size of the pizza wasn't being taken into consideration when doing the sum, thus returning an incorrect value.

